### PR TITLE
subtitle: count Text/Image elements accurately and align the Image limit with ST 429-2

### DIFF
--- a/clairmeta/dcp_check_subtitle.py
+++ b/clairmeta/dcp_check_subtitle.py
@@ -23,6 +23,57 @@ from clairmeta.settings import DCP_SETTINGS
 from clairmeta.logger import get_log
 
 
+def collect_subtitle_elements(node, name):
+    """Every <name> element instance contained in a subtitle subtree.
+
+    WHY THIS EXISTS -- keys_by_name_dict() cannot be used to enumerate or count
+    elements. parse_xml stores an element's TEXT under a key equal to the
+    element name, alongside its attributes, so three <Image> elements become
+
+        {"Image": [{"Image@VAlign": "bottom", "Image": "a.png"},
+                   {"Image@VAlign": "bottom", "Image": "b.png"},
+                   {"Image@VAlign": "bottom", "Image": "c.png"}]}
+
+    keys_by_name_dict then matches the CONTAINER list *and* each element's text
+    child, returning a mixed list of n + 1 entries. Counting it reports one
+    element too many -- which rejects a subtitle carrying the legal maximum --
+    and iterating it yields the container list where a caller expects a
+    filename, which raises TypeError.
+
+    This returns one entry per element instance. An entry is a dict when the
+    element carries attributes and a plain string when it does not; use
+    subtitle_element_value() to get its text either way. Non-matching branches
+    are still traversed, so elements nested in a <Font> wrapper are found.
+    """
+    found = []
+    if isinstance(node, list):
+        for item in node:
+            found += collect_subtitle_elements(item, name)
+    elif isinstance(node, dict):
+        for key, value in node.items():
+            if key == name:
+                found += value if isinstance(value, list) else [value]
+            else:
+                found += collect_subtitle_elements(value, name)
+    return found
+
+
+def subtitle_element_value(element, name):
+    """Text of one element returned by collect_subtitle_elements().
+
+    With attributes the element is a dict carrying its text under the element
+    name; without attributes it is already the text.
+    """
+    if isinstance(element, dict):
+        return element.get(name)
+    return element
+
+
+def count_subtitle_elements(node, name):
+    """Number of <name> element instances (see collect_subtitle_elements)."""
+    return len(collect_subtitle_elements(node, name))
+
+
 class SubtitleUtils(object):
     def __init__(self, dcp):
         self.dcp = dcp
@@ -568,19 +619,17 @@ class Checker(CheckerBase):
             return
 
         for idx, st in enumerate(subtitles[0]):
-            text_count = len(keys_by_name_dict(st, "Text"))
+            text_count = count_subtitle_elements(st, "Text")
             if text_count > 6:
                 self.error(
-                    "Too many Text elements ({}) for subtitle {}".format(
-                        text_count, st["Subtitle@SpotNumber"]
-                    )
+                    "Too many Text elements ({}, maximum is 6) for subtitle "
+                    "{}".format(text_count, st["Subtitle@SpotNumber"])
                 )
-            img_count = len(keys_by_name_dict(st, "Image"))
-            if img_count > 6:
+            img_count = count_subtitle_elements(st, "Image")
+            if img_count > 3:
                 self.error(
-                    "Too many Image elements ({}) for subtitle {}".format(
-                        img_count, st["Subtitle@SpotNumber"]
-                    )
+                    "Too many Image elements ({}, maximum is 3) for subtitle "
+                    "{}".format(img_count, st["Subtitle@SpotNumber"])
                 )
 
     def check_subtitle_cpl_duration(self, playlist, asset, folder):
@@ -836,8 +885,13 @@ class Checker(CheckerBase):
         if self.dcp.schema != "Interop":
             return
 
-        imgs = keys_by_name_dict(st_dict, "Image")
-        for img in imgs:
+        # keys_by_name_dict would hand us the container list as well as the
+        # filenames; joining that list onto a path raises TypeError. Enumerate
+        # element instances instead and take each one's text.
+        for element in collect_subtitle_elements(st_dict, "Image"):
+            img = subtitle_element_value(element, "Image")
+            if not isinstance(img, str) or not img:
+                continue
             if not os.path.exists(os.path.join(folder, img)):
                 self.error(
                     "Subtitle image reference {} not found in folder {}"


### PR DESCRIPTION
Addresses items 4–6 of #262.

Three related improvements in subtitle element handling, all stemming from how `keys_by_name_dict` interacts with the parsed structure.

`parse_xml` stores an element's text under a key equal to the element name, alongside its attributes, so three `<Image>` elements become:

```python
{"Image": [{"Image@VAlign": "bottom", "Image": "a.png"},
           {"Image@VAlign": "bottom", "Image": "b.png"},
           {"Image@VAlign": "bottom", "Image": "c.png"}]}
```

`keys_by_name_dict(st, "Image")` therefore returns `[<the list>, 'a.png', 'b.png', 'c.png']` — **n + 1 entries, of mixed type**.

- `check_subtitle_cpl_max_elements` takes `len()` of that, so the count comes out one high for both Text and Image. Together with the Image threshold being `> 6` where ST 429-2:2020 §8.4.4 says three, instances with 4–6 images pass while an instance with the **legal maximum of six Text elements is already turned away**.
- `check_subtitle_cpl_image` iterates it and joins each entry onto a path, so the container list reaches `os.path.join` and raises `TypeError` whenever an Image element carries positioning attributes.

`collect_subtitle_elements()` returns one entry per element instance and does not rescan a matched element's own subtree, so the text child is never double counted; non-matching branches are still traversed so elements nested in a `<Font>` wrapper are still found. `subtitle_element_value()` reads an element's text whether or not it has attributes. `count_subtitle_elements()` is `len()` of the collector.

**Verified** on Interop DCPs: 3 images silent; 3 images with no Text silent; 4 images reported as 4; 2 images with one dangling reference reports only the dangling one. Unit-checked across 0/1/2/3/4 images with and without attributes, images nested in `<Font>`, and 6 vs 7 Text.