### PR TITLE
Quiet three findings on conformant DCPs (VOLINDEX, foreign files, asdcp working directory)

### DIFF
--- a/clairmeta/dcp_check_global.py
+++ b/clairmeta/dcp_check_global.py
@@ -79,7 +79,11 @@ class Checker(CheckerBase):
         }
 
         for k, v in restricted_lists.items():
-            if len(v) == 0:
+            # VolumeIndex is deprecated (ST 429-9:2014 section 8) and optional;
+            # only the AssetMap is mandatory. A conformant single-volume SMPTE
+            # DCP commonly omits VOLINDEX, so do not flag a missing one. Having
+            # more than one of either file remains an error.
+            if len(v) == 0 and k == "Assetmap":
                 self.error("Missing {} file".format(k))
             if len(v) > 1:
                 self.error("Multiple {} files found".format(k))

--- a/clairmeta/dcp_check_global.py
+++ b/clairmeta/dcp_check_global.py
@@ -53,16 +53,22 @@ class Checker(CheckerBase):
 
         References: N/A
         """
+        # AssetMap <Path> values use forward slashes; _list_files comes from
+        # os.walk and uses the platform separator. On Windows an asset in a
+        # sub-directory (the normal Interop layout, where the subtitle XML and
+        # its font live in a UUID-named folder) therefore never compares equal
+        # and is reported as foreign although it IS listed. Normalise both sides.
         list_asset_path = [
-            os.path.join(self.dcp.path, a) for a in self.dcp._list_asset.values()
+            os.path.normpath(os.path.join(self.dcp.path, a))
+            for a in self.dcp._list_asset.values()
         ]
-        list_asset_path += self.dcp._list_vol_path
-        list_asset_path += self.dcp._list_am_path
+        list_asset_path += [os.path.normpath(p) for p in self.dcp._list_vol_path]
+        list_asset_path += [os.path.normpath(p) for p in self.dcp._list_am_path]
 
         self.dcp.foreign_files = [
             os.path.relpath(a, self.dcp.path)
             for a in self.dcp._list_files
-            if a not in list_asset_path
+            if os.path.normpath(a) not in list_asset_path
             and not any([re.search(i, a) for i in self.allowed_foreign_files])
         ]
         if self.dcp.foreign_files:

--- a/clairmeta/utils/probe.py
+++ b/clairmeta/utils/probe.py
@@ -219,7 +219,25 @@ def unwrap_mxf(path, prefix=None, args=[]):
         unwrap_args = [ASDCP_UNWRAP_CMD, path, unwrap_prefix]
         unwrap_args += args
 
-        execute_command(unwrap_args)
+        # asdcp-unwrap writes the essence to the given prefix, but emits
+        # ANCILLARY RESOURCES (e.g. the font of a timed text asset) into the
+        # process working directory under their bare UUID. Left alone, those
+        # land wherever the host application happens to be running: the caller
+        # then cannot find them here (a guaranteed false "missing font file"
+        # on any conformant SMPTE DCP with an embedded font) and the host
+        # directory accumulates a stray file on every run.
+        #
+        # The working directory is moved around the call rather than passed as
+        # an argument: execute_command is a documented seam that host
+        # applications wrap for logging, and adding a keyword argument breaks
+        # any wrapper carrying the original signature. unwrap_prefix is an
+        # absolute path, so the essence output is unaffected.
+        cwd = os.getcwd()
+        try:
+            os.chdir(tmp)
+            execute_command(unwrap_args)
+        finally:
+            os.chdir(cwd)
         yield tmp
 
 


### PR DESCRIPTION
Addresses items 1–3 of #262. Three independent commits; each stands alone.

1. **VOLINDEX no longer required.** ST 429-9:2014 §8 deprecates the structure, §7.2 permits its absence, §5.4 fixes VolumeCount at 1. Only the AssetMap is now required present; both "multiple files found" guards are unchanged. This also lets two checks agree — `check_assets_am_volindex_one` already treats VolumeIndex as optional and is WARNING by default, while this check sits outside the criticality map and so defaults to ERROR.

2. **Foreign-file path separators normalised.** AssetMap paths use `/`, `os.walk` uses the platform separator, so on Windows an asset in a sub-directory never matched and was reported foreign. This hits the ordinary Interop layout, where the subtitle XML and font live in a UUID-named folder.

3. **`asdcp-unwrap` now runs in the directory it writes into.** It emits ancillary resources into the working directory under their bare UUID, while `unwrap_mxf` yields a temp directory that `check_subtitle_cpl_font` then searches — hence a guaranteed "missing font file" on any SMPTE DCP with an embedded font, plus a stray file left in the host's working directory each run.

   The working directory is moved around the call rather than passed to `execute_command`, deliberately: `execute_command` is a seam host applications wrap for logging, and adding a keyword argument raises `TypeError` inside any wrapper carrying the original signature. I hit exactly that. `unwrap_prefix` is absolute so the essence output is unaffected. The reasoning is recorded at the call site.

**Verified** against conformant SMPTE and Interop control DCPs: all three findings disappear, no other check changes, and a full run leaves no stray file.