### PR TITLE
Refresh DCNC grammar, add XMLDSIG citations, ease one default severity

### DIFF
--- a/clairmeta/dcp_check_sign.py
+++ b/clairmeta/dcp_check_sign.py
@@ -666,7 +666,11 @@ class Checker(CheckerBase):
     def check_sign_signature_algorithm(self, source):
         """XML signature algorithm check.
 
-        References: N/A
+        References:
+            SMPTE ST 429-8:2007 5.10
+            SMPTE ST 429-7:2006 6.13
+            IETF RFC 4051 (XML-Signature SignatureMethod URIs)
+            IETF RFC 3275 (XML-Signature Syntax and Processing)
         """
         # Additionnal. XML coherence checks
         signed_info = source["Signature"]["SignedInfo"]
@@ -683,7 +687,8 @@ class Checker(CheckerBase):
     def check_sign_canonicalization_algorithm(self, source):
         """XML canonicalization algorithm check.
 
-        References: N/A
+        References:
+            IETF RFC 3275 (XML-Signature Syntax and Processing)
         """
         signed_info = source["Signature"]["SignedInfo"]
         # Canonicalization algorithm
@@ -694,7 +699,8 @@ class Checker(CheckerBase):
     def check_sign_transform_algorithm(self, source):
         """XML signature transform algorithm check.
 
-        References: N/A
+        References:
+            IETF RFC 3275 (XML-Signature Syntax and Processing)
         """
         signed_info = source["Signature"]["SignedInfo"]
         # Transform alogrithm
@@ -705,7 +711,8 @@ class Checker(CheckerBase):
     def check_sign_digest_algorithm(self, source):
         """XML signature digest method check.
 
-        References: N/A
+        References:
+            IETF RFC 3275 (XML-Signature Syntax and Processing)
         """
         signed_info = source["Signature"]["SignedInfo"]
         # Digest algorithm
@@ -716,7 +723,8 @@ class Checker(CheckerBase):
     def check_sign_issuer_name(self, source):
         """XML signature issuer name check.
 
-        References: N/A
+        References:
+            IETF RFC 3275 (XML-Signature Syntax and Processing)
         """
         signer = source["Signer"]["X509Data"]["X509IssuerSerial"]
         # Signer Issuer Name
@@ -729,7 +737,8 @@ class Checker(CheckerBase):
     def check_sign_issuer_serial(self, source):
         """XML signature serial number check.
 
-        References: N/A
+        References:
+            IETF RFC 3275 (XML-Signature Syntax and Processing)
         """
         sig = source["Signer"]["X509Data"]["X509IssuerSerial"]
         # Signer Serial number

--- a/clairmeta/profile.py
+++ b/clairmeta/profile.py
@@ -38,6 +38,7 @@ DCP_CHECK_PROFILE = {
         "check_subtitle_cpl_uuid_case": "WARNING",
         "check_subtitle_cpl_duplicated_uuid": "WARNING",
         "check_subtitle_cpl_first_tt_event": "WARNING",
+        "check_subtitle_cpl_position": "WARNING",
         "check_picture_cpl_archival_framerate": "WARNING",
         "check_picture_cpl_hfr_framerate": "WARNING",
         "check_sound_cpl_format": "WARNING",

--- a/clairmeta/utils/isdcf.py
+++ b/clairmeta/utils/isdcf.py
@@ -29,7 +29,8 @@ RULES = {
         'FilmTitle': r'(^[a-zA-Z0-9-]{1,14}$)',
         'ContentType':
             r'(^'
-            r'(?P<Type>FTR|EPS|TLR|TSR|PRO|TST|RTG-F|RTG-T|SHR|ADV|XSN|PSA|POL)'
+            r'(?P<Type>FTR|EPS|TLR|TSR|PRO|TST|RTG-F|RTG-T|RTG|SHR|ADV|XSN|PSA|POL'
+            r'|CLP|STR|HLT|EVT)'
             r'(-(?P<Version>\d))?'
             r'(-(?P<Temporary>Temp))?'
             r'(-(?P<PreRelease>Pre))?'
@@ -64,7 +65,7 @@ RULES = {
             r'(-(?P<HearingImpaired>HI))?'
             r'(-(?P<VisionImpaired>VI))?'
             r'(-(?P<SignLanguage>SL))?'
-            r'(-(?P<ImmersiveSound>(ATMOS|Atmos|AURO|DTS-X)))?'
+            r'(-(?P<ImmersiveSound>(ATMOS|Atmos|AURO|DTS-X|IAB)))?'
             r'(-(?P<MotionSimulator>(DBOX|Dbox)))?'
             r'$)',
         'Resolution': r'(^2K|4K$)',


### PR DESCRIPTION
Addresses items 7–8 of #262. Three small independent commits.

1. **DCNC grammar** gains Content Types `RTG`, `CLP`, `STR`, `HLT`, `EVT` and the `IAB` immersive-audio label, per the live registry. `RTG-F`/`RTG-T` are kept ahead of `RTG` so legacy titles still match.

2. **Six XMLDSIG checks** gain their `References:` blocks (RFC 3275/4051 as used by ST 429-7 §6.13 / ST 429-8 §5.10). Docstrings only, no behaviour change. `check_sign_chain_coherence_signature_algorithm` is deliberately left `N/A` — consistency hardening with no single normative clause.

3. **`check_subtitle_cpl_position` → WARNING.** `VPosition=0` is legal per ST 428-7 §6.2.4 Table 3, so the check is advisory; this matches its sibling subtitle heuristics already in the map.